### PR TITLE
bind/unbind to function reference

### DIFF
--- a/massautocomplete.js
+++ b/massautocomplete.js
@@ -172,7 +172,7 @@ angular.module('MassAutoComplete', [])
 
         // Clear references and events.
         $scope.show_autocomplete = false;
-        angular.element($window).unbind(EVENTS.RESIZE);
+        angular.element($window).unbind(EVENTS.RESIZE, position_autocomplete);
         value_watch && value_watch();
         $scope.selected_index = $scope.results = undefined;
         current_model = current_element = previous_value = undefined;


### PR DESCRIPTION
Hello hakib,

First, i'd like to thank you for this amazing utility that is angular-mass-autocomplete.
I also would like to share a problem I encounter using it in an app where I already had a listener for `$window resize event`: it happens that when i enter and leave, the unbind that was called in your library unbind all registered handlers for `$window resize event`.

So I simply update the library to use unbind in the form `unbind(event, function reference)` instead of `unbind(event)` and it happens to work as expected.

I also took the liberty to reference your handlers for the *keydown* and *blur* events you are binding to the *current_element*, so further calls to unbind can use these references and be more accurate.

Thank you again for this library.

Regards.
David