### PR TITLE
Use of $timeout instead of setTimeout

### DIFF
--- a/massautocomplete.js
+++ b/massautocomplete.js
@@ -117,18 +117,18 @@ angular.module('MassAutoComplete', [])
 
       // Debounce - taken from underscore.
       function debounce(func, wait, immediate) {
-        var timeout;
+        var timeoutPromise;
         return function() {
           var context = this, args = arguments;
           var later = function() {
-            timeout = null;
+            timeoutPromise = null;
             if (!immediate) {
               func.apply(context, args);
             }
           };
-          var callNow = immediate && !timeout;
-          clearTimeout(timeout);
-          timeout = setTimeout(later, wait);
+          var callNow = immediate && !timeoutPromise;
+          $timeout.cancel(timeoutPromise);
+          timeoutPromise = $timeout(later, wait);
           if (callNow) {
             func.apply(context, args);
           }


### PR DESCRIPTION
The `debounce()` function, apparently taken from `underscore`, uses setTimeout. As a result, angular misses the changes, and the autocomplete's `suggest()` is not triggered until the next `$digest` (usually a mouseout event).
Changing from `setTimeout()` to `$timeout` fixes the problem.
Cheers!